### PR TITLE
Auto units; function for retrieving icon

### DIFF
--- a/lib/forecast.io.php
+++ b/lib/forecast.io.php
@@ -171,6 +171,17 @@ class ForecastIOConditions{
     return $this->raw_data->summary;
     
   }
+
+  /**
+   * Get the icon of the conditions
+   * 
+   * @return String
+   */
+  function getIcon() {
+    
+    return $this->raw_data->icon;
+    
+  }
   
   /**
    * Get the time, when $format not set timestamp else formatted time


### PR DESCRIPTION
Wasn't immediately obvious to a rookie like me why units were metric. Using units=auto would resolve that without requiring another variable to be set.

Also, wanted to play around with [Skycons](https://github.com/darkskyapp/skycons), so being able to set the forecast icon as the id for the canvas element seemed logical. Or use one of the weather icon fonts for that matter.
