### PR TITLE
add getTemperaturMax and getTemperatureMin

### DIFF
--- a/lib/forecast.io.php
+++ b/lib/forecast.io.php
@@ -162,6 +162,32 @@ class ForecastIOConditions{
   }
   
   /**
+   * get the min temperature
+   * 
+   * only available for week forecast
+   * 
+   * @return type
+   */
+  function getMinTemperature() {
+    
+    return $this->raw_data->temperatureMin;
+    
+  }
+  
+  /**
+   * get max temperature
+   * 
+   * only available for week forecast
+   * 
+   * @return type
+   */
+  function getMaxTemperature() {
+    
+    return $this->raw_data->temperatureMax;
+    
+  }
+  
+  /**
    * Get the summary of the conditions
    * 
    * @return String


### PR DESCRIPTION
Using getForecastWeek, condition getTemperature returns nothing. Apparently api returns min and max temperature.
