### PR TITLE
Update forecast.io.php

### DIFF
--- a/lib/forecast.io.php
+++ b/lib/forecast.io.php
@@ -33,7 +33,7 @@ class ForecastIO{
     
     $content = file_get_contents($request_url);
     
-    if ($content != '' && isset($content)) {
+    if (!empty($content)) {
       
       return json_decode($content);
        


### PR DESCRIPTION
The check for $content != '' before the isset check could lead to errors. The !empty check will do both an isset check as well as a check that it contains data.
